### PR TITLE
Set the eslint-loader option emitWarning to true

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ function rewireHotLoader(config, env) {
     return config;
   }
 
+  config.module.rules[0].use[0].options.emitWarning = true;
   return injectBabelPlugin(['react-hot-loader/babel'], config);
 }
 


### PR DESCRIPTION
Prevents HMR from breaking if eslint emits an error. Closes #7.