### PR TITLE
Remove Deprecated injectBabelPlugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 const webpack = require('webpack');
-const {injectBabelPlugin} = require('react-app-rewired');
 
 function rewireHotLoader(config, env) {
   if (env === 'production') {
@@ -19,7 +18,7 @@ function rewireHotLoader(config, env) {
     }
   }
 
-  return injectBabelPlugin(['react-hot-loader/babel'], config);
+  return config;
 }
 
 module.exports = rewireHotLoader;


### PR DESCRIPTION
The new version of `react-app-rewired` (>2.0) removed all the methods like `injectBabelPlugin`. This causes `react-app-rewire-hot-loader` to error out when trying to require and use it from `react-app-rewired`. 

I made a quick fix to get the package working again, and as far as I can tell no functionality was lost. I'm not entirely sure what's going on behind the scenes of `react-app-rewired` and `react-hot-loader`, but they must be handling the necessary babel plugin in a different fashion now.