### PR TITLE
Fixed issues with removing injectBabelPlugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,34 @@
-const webpack = require('webpack');
-const {injectBabelPlugin} = require('react-app-rewired');
+// Mostly inlined from 'customize-cra' https://www.npmjs.com/package/customize-cra
+// The whole library is extremely useful, but the only tool needed here is addBabelLoader.
+const getBabelLoader = config => {
+  // Filtering out rules that don't define babel plugins.
+  const babelLoaderFilter = rule =>
+    rule.loader &&
+    rule.loader.includes("babel") &&
+    rule.options &&
+    rule.options.plugins;
+
+  // First, try to find the babel loader inside the oneOf array.
+  // This is where we can find it when working with react-scripts@2.0.3.
+  let loaders = config.module.rules.find(rule => Array.isArray(rule.oneOf))
+    .oneOf;
+
+  let babelLoader = loaders.find(babelLoaderFilter);
+
+  // If the loader was not found, try to find it inside of the "use" array, within the rules.
+  // This should work when dealing with react-scripts@2.0.0.next.* versions.
+  if (!babelLoader) {
+    loaders = loaders.reduce((ldrs, rule) => ldrs.concat(rule.use || []), []);
+    babelLoader = loaders.find(babelLoaderFilter);
+  }
+  return babelLoader;
+}
+
+// Curried function that uses config to search for babel loader and pushed new plugin to options list.
+const addBabelPlugin = plugin => config => {
+  getBabelLoader(config).options.plugins.push(plugin);
+  return config;
+};
 
 function rewireHotLoader(config, env) {
   if (env === 'production') {
@@ -18,8 +47,9 @@ function rewireHotLoader(config, env) {
       use.options.emitWarning = true;
     }
   }
-
-  return injectBabelPlugin(['react-hot-loader/babel'], config);
+  
+  // If in development, add 'react-hot-loader/babel' to babel plugins
+  return addBabelPlugin('react-hot-loader/babel')(config);
 }
 
 module.exports = rewireHotLoader;

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
-// Mostly inlined from 'customize-cra' https://www.npmjs.com/package/customize-cra
-// The whole library is extremely useful, but the only tool needed here is addBabelLoader.
+// Mostly inlined from within `customize-cra` https://www.npmjs.com/package/customize-cra
 const getBabelLoader = config => {
   // Filtering out rules that don't define babel plugins.
   const babelLoaderFilter = rule =>
@@ -24,7 +23,7 @@ const getBabelLoader = config => {
   return babelLoader;
 }
 
-// Curried function that uses config to search for babel loader and pushed new plugin to options list.
+// Curried function that uses config to search for babel loader and pushes new plugin to options list.
 const addBabelPlugin = plugin => config => {
   getBabelLoader(config).options.plugins.push(plugin);
   return config;
@@ -48,7 +47,7 @@ function rewireHotLoader(config, env) {
     }
   }
   
-  // If in development, add 'react-hot-loader/babel' to babel plugins
+  // If in development, add 'react-hot-loader/babel' to babel plugins.
   return addBabelPlugin('react-hot-loader/babel')(config);
 }
 


### PR DESCRIPTION
I was too hasty with my approach in simply deleting the deprecated injectBabelPlugin function imported from  `react-app-rewired`. It did solve the major issue of `react-app-rewire-hot-loader` causing compile failure, but Babel no longer used the correct plugin. In `react-app-rewire-hot-loader`'s current state, hot loading is impossible and thus the functionality of this package and peer dependencies were ruined.

This pull request fixes the issue by adding custom a Babel plugin injector function. Thanks to @esetnik for pointing me in the right direction with the [`customize-cra`](https://www.npmjs.com/package/customize-cra) project, which is where a lot of these changes were inspired. `react-app-rewire-hot-loader` should now work with both older, newer, and future versions of `react-hot-loader`, since it no longer relies on any imported internal functions.