### PR TITLE
Update usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,23 @@ module.exports = function override (config, env) {
 
 2. Follow 'step 2' from https://github.com/gaearon/react-hot-loader , replicated below:
 
-```js
 Mark your root component as hot-exported:
-// App.js
+```js
+// App.js - react-hot-loader >= 4.5.4
+import React from 'react'
+import { hot } from 'react-hot-loader/root'
+
+const App = () => <div>Hello World!</div>
+
+export default process.env.NODE_ENV === "development" ? hot(App) : App
+```
+__Old version__: Prior to react-hot-loader version 4.5.4. you needed to write `hot(module)(App)`.
+
+[react-hot-loader](https://github.com/gaearon/react-hot-loader/tree/v4.7.1#getting-started) recommends to use the latest syntax as
+_"it is much more resilient to js errors you may make during development."_
+
+```js
+// App.js - react-hot-loader < 4.5.4
 import React from 'react'
 import { hot } from 'react-hot-loader'
 


### PR DESCRIPTION
since v4.5.4 react-hot-loader has changed api
from `hot(module)(App)` to `hot(App)`.
we update the README to reflect the change.